### PR TITLE
Download page - macOS-related adjustments

### DIFF
--- a/content/themes/osmc/page-download.hbs
+++ b/content/themes/osmc/page-download.hbs
@@ -43,10 +43,16 @@
     {{> svg/osx}}
     <div class="download-system-wrap">
       <a href="https://ftp.fau.de/osmc/osmc/download/installers/osmc-installer.dmg" class="download-system-dl">
-        <span class="download-system-title ani1">OS X</span>
+        <span class="download-system-title ani1">macOS</span>
         {{> svg/download}}
       </a>
-      <span class="download-system-meta">10.07 +</span>
+      <span class="download-system-meta">
+        10.7-10.14
+        <br>
+        Catalina and Big Sur
+        <br>
+        guidance <a href="https://discourse.osmc.tv/t/how-to-prepare-a-bootable-osmc-image-on-macos-catalina-and-big-sur/87490" target="_blank">here</a>
+      </span>
     </div>
   </div>
 </section>

--- a/content/themes/osmc/page-download.hbs
+++ b/content/themes/osmc/page-download.hbs
@@ -51,7 +51,7 @@
         <br>
         Catalina and Big Sur
         <br>
-        guidance <a href="https://discourse.osmc.tv/t/how-to-prepare-a-bootable-osmc-image-on-macos-catalina-and-big-sur/87490" target="_blank">here</a>
+        guidance <a href="https://osmc.tv/wiki/general/how-to-prepare-a-bootable-osmc-image-on-macos-catalina-and-big-sur/" target="_blank">here</a>
       </span>
     </div>
   </div>

--- a/src/assets/style/modules/download.scss
+++ b/src/assets/style/modules/download.scss
@@ -146,6 +146,17 @@
       color: $acc3-2;
       display: block;
       margin-top: 0.2em;
+      a,
+      a:visited {
+        color: $acc3-2;
+        border-bottom: 1px solid rgba(0,0,0,0.08);
+        &:hover,
+        &:active,
+        &:focus {
+          color: $link;
+          border-bottom: 1px solid $link;
+        }
+      }
     }
   }
   &-tables {


### PR DESCRIPTION
Changes:
* Replaced outdated title from OS X to macOS
* Corrected supported versions from incorrect 10.07+ to 10.7-10.15
* Added a note with a link to guidance for macOS Catalina and Big Sur users.